### PR TITLE
Add socket_opts options to ESME

### DIFF
--- a/lib/smppex/esme.ex
+++ b/lib/smppex/esme.ex
@@ -77,6 +77,7 @@ defmodule SMPPEX.ESME do
       - `:session_init_limit` is the maximum time for the session to be unbound.
       If no bind request succeed within this interval of time, the session stops.
       The default value is #{inspect(Defaults.session_init_limit())} ms;
+  * `:socket_opts` is a keyword list of ranch socket options, see ranch's options for more information
   If `:esme_opts` list of options is ommited, all options take their default values.
   The whole `opts` argument may also be ommited in order to start ESME with the defaults.
   The returned value is either `{:ok, pid}` or `{:error, reason}`.
@@ -84,7 +85,12 @@ defmodule SMPPEX.ESME do
   def start_link(host, port, {_module, _args} = mod_with_args, opts \\ []) do
     transport = Keyword.get(opts, :transport, @default_transport)
     timeout = Keyword.get(opts, :timeout, @default_timeout)
-    sock_opts = [:binary, {:packet, 0}, {:active, :once}]
+    sock_opts = [
+                  :binary,
+                  {:packet, 0},
+                  {:active, :once}
+                  | Keyword.get(opts, :socket_opts, [])
+                ]
     esme_opts = Keyword.get(opts, :esme_opts, [])
 
     case transport.connect(convert_host(host), port, sock_opts, timeout) do

--- a/test/support/ssl/esme.ex
+++ b/test/support/ssl/esme.ex
@@ -13,12 +13,7 @@ defmodule Support.SSL.ESME do
       @host,
       port,
       {__MODULE__, %{pid: self()}},
-      transport: :ranch_ssl,
-      transport_opts: [
-        port: port,
-        certfile: 'test/support/ssl/host.crt',
-        keyfile: 'test/support/ssl/host.key'
-      ]
+      transport: :ranch_ssl
     )
   end
 


### PR DESCRIPTION
I needed to make some changes to the ESME's socket configuration, specifically overriding the supported SSL ciphers (erlang changed the defaults recently and we needed the old ones)

This PR adds the socket_opts keyword pair to the ESME opts allowing users to add additional socket options to the connection, the specific options supported are purposely omitted from the docs as they vary on the transport.

We've been running this for a few months now in production and has worked without issue.

I've also corrected the misleading transport_opts in the ESME test (as it wasn't implemented in the module to begin with)